### PR TITLE
Fix twitter engine for new site design

### DIFF
--- a/src/engines/Twitter.ts
+++ b/src/engines/Twitter.ts
@@ -1,47 +1,45 @@
 import { ScrapeEngine, ScrapeResult, ScrapedPost } from "../ScrapeEngine";
 import { guessContentType } from "../Utility";
 
-export function getOriginalImageUrl(imageUrl: string) {
-  const x = imageUrl.replace(/:large|:med|:small|:orig$/, ""); // Remove `:large`, `:small` etc from url
-  return x + ":orig"; // Add :orig to url (to get original image)
+export function getOriginalImageUrl(image: HTMLImageElement) {
+  // if the link includes a resolution, change it to orig:
+  // https://pbs.twimg.com/media/stuff?format=jpg&name=900x900
+  // -> https://pbs.twimg.com/media/stuff?format=jpg&name=orig
+  let img_url = new URL((image as HTMLImageElement).src);
+  if (img_url.searchParams.has('name') && img_url.searchParams.get('name') != 'orig') {
+    img_url.searchParams.set('name', 'orig');
+  }
+  return img_url;
 }
 
 export default class Twitter implements ScrapeEngine {
   name = "twitter";
 
   canImport(url: Location): boolean {
-    return url.host == "twitter.com";
+    return url.host == "twitter.com" || url.host == "mobile.twitter.com";
   }
 
   scrapeDocument(document: Document): ScrapeResult {
     let result = new ScrapeResult(this.name);
-    let post = new ScrapedPost();
-    post.pageUrl = document.location.href;
 
-    // Set image url
-    // When clicked on post (not fullscreen, with post text etc)
-    const overlayElement = document.querySelector("#permalink-overlay-dialog");
-    if (overlayElement) {
-      const cardImageElement = overlayElement.querySelector("div[data-element-context='platform_photo_card'] > img");
-      if (cardImageElement) {
-        post.contentUrl = getOriginalImageUrl((cardImageElement as HTMLImageElement).src);
-      }
+    // first look for a focused image on desktop:
+    const center_img = document.querySelector("div[role=dialog] div[role=dialog] div[aria-label=Image] img");
+    if (center_img) {
+      let post = new ScrapedPost();
+      post.pageUrl = document.location.href;
+      post.contentUrl = getOriginalImageUrl(center_img as HTMLImageElement).href;
+      result.tryAddPost(post);
     }
 
-    // When clicked on image (fullscreen)
-    const mediaImageElements = document.querySelectorAll("div.Gallery-media > img.media-image");
-    if (mediaImageElements.length > 0) {
-      post.contentUrl = getOriginalImageUrl((mediaImageElements[0] as HTMLImageElement).src);
+    // look for images within a tweet:
+    const imgs = [...document.querySelectorAll("article a[role='link'] div[data-testid='tweetPhoto'] img")];
+
+    for (const img of imgs) {
+      let post = new ScrapedPost();
+      post.pageUrl = document.location.href;
+      post.contentUrl = getOriginalImageUrl(img as HTMLImageElement).href;
+      result.tryAddPost(post);
     }
-
-    if (post.contentUrl == undefined) {
-      return result;
-    }
-
-    // Set content type
-    post.contentType = guessContentType(post.contentUrl);
-
-    result.tryAddPost(post);
 
     return result;
   }


### PR DESCRIPTION
Tested with Firefox, uses new `URL` standard web api.

Also captures images from replies, etc, but they always come after the current tweet's images so that seems acceptable.