### PR TITLE
Quickfix for Philomena resolution

### DIFF
--- a/src/engines/Philomena.ts
+++ b/src/engines/Philomena.ts
@@ -49,7 +49,7 @@ export default class Philomena extends ScrapeEngineBase {
     post.rating = "unsafe";
 
     // Set resolution
-    const resStr = (<HTMLElement>document.querySelector("span[class='image-size']"))?.innerText?.split(" ")[0];
+    const resStr = (<HTMLElement>document.querySelector("span[class='image-size']"))?.innerText?.match(/(\d+x\d+)/)?.[0];
     if (resStr) {
       const res = parseResolutionString(resStr);
       if (res) {


### PR DESCRIPTION
A fix for resolution on animated images and video. Resolution string was not parsing correctly and included the video length as part of the resolution. Resulting in "1280x720000401".

This isn't a mandatory fix, more of a visual problem than anything else. Does not affect importing process at all.